### PR TITLE
Added Make build-script for UNIX-systems. Also added missing header for FLT_MAX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ odyssey2/Debug/
 odyssey2/x64/
 x64/
 2048_island*
+*.o
+*.out

--- a/odyssey2/Makefile
+++ b/odyssey2/Makefile
@@ -1,0 +1,18 @@
+CC = g++
+CFLAGS = -Wall -Wextra -Wpedantic -Idependencies -Idependencies/glad/include -O3 -march=native
+CXXFLAGS = $(CFLAGS) -Weffc++ -std=c++17
+LINK = -ldl -lglfw
+
+.PHONY: game.out clean
+
+%.o: %.cpp
+	$(CC) $(CXXFLAGS) -c $^ -o $@
+
+OBJECTS = $(patsubst %.cpp,%.o,$(wildcard *.cpp)) dependencies/glad/src/glad.o
+
+game.out: $(OBJECTS)
+	$(CC) $(CXXFLAGS) $^ $(LINK) -o game.out
+
+clean:
+	@rm -rfv $(OBJECTS)
+	@rm -vf game.out

--- a/odyssey2/util_misc.h
+++ b/odyssey2/util_misc.h
@@ -3,6 +3,7 @@
 #include <glad/glad.h>
 #include <unordered_map>
 #include <vector>
+#include <cfloat>
 
 struct Terrain_heights
 {


### PR DESCRIPTION
I added a Makefile for UNIX build systems and was able to compile the project on my own machine. I also added a missing `#include <cfloat>` for proper use of `FLT_MAX`.

The demo ran great on my computer and it looks beautiful! :+1: 